### PR TITLE
Remove -Xshare:on from Java flags

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'com.github.ev3dev-lang-java'
-version '1.6.4'
+version '1.6.5'
 
 sourceCompatibility = 1.8
 

--- a/src/main/groovy/com/github/elj/gradle/Preferences.groovy
+++ b/src/main/groovy/com/github/elj/gradle/Preferences.groovy
@@ -16,7 +16,7 @@ class Preferences {
     boolean useTime = true
     boolean useBrickrun = false
 
-    def jvmFlags = ["-Xms64m", "-Xmx64m", "-XX:+UseSerialGC", "-Xshare:on", "-noverify"]
+    def jvmFlags = ["-Xms64m", "-Xmx64m", "-XX:+UseSerialGC", "-noverify"]
 
     boolean slimJar = true
     boolean useEmbeddedPaths = true


### PR DESCRIPTION
Xshare:on breaks the plugin on Raspberry Pi. Apparently the CDS cache is sometimes not generated properly on Raspbian. This means that we either have to generate the cache in our tooling, or that we have to disable -Xshare:on.

I think the best solution is to use default Java configuration. Citing from https://docs.oracle.com/javase/9/vm/class-data-sharing.htm:

> ```
> -Xshare:auto
>     The default; enable class data sharing whenever possible.
> ```

This means that on EV3, it should pick up the cache generated by JRI package postinst or by the tarball installation script. On systems where the CDS cache is not available, it ensures that the execution proceeds, albeit it will have a bit slower startup.

We can combine this with change with the introduction of -Xshare:dump for Raspberry's in installer.sh. After that is finished, this commit ensures that old setups will work as intended.

The plugin version is bumped to 1.6.5.

Fixes https://github.com/ev3dev-lang-java/gradle-plugin/issues/2.