### PR TITLE
Fix runtime deps

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'com.github.ev3dev-lang-java'
-version '1.6.5'
+version '1.6.6'
 
 sourceCompatibility = 1.8
 

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,5 @@ dependencies {
     implementation localGroovy()
     implementation      group: 'com.jcraft',                          name: 'jsch',       version: '0.1.55'
     implementation      group: 'com.github.jengelman.gradle.plugins', name: 'shadow',     version: '4.0.3'
-    annotationProcessor group: 'org.apache.logging.log4j',            name: 'log4j-core', version: '2.11.1'
     testImplementation  group: 'junit',                               name: 'junit',      version: '4.12'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -25,11 +25,10 @@ jar {
 }
 
 dependencies {
-    compile gradleApi()
-    compile localGroovy()
-    compile group: 'com.jcraft', name: 'jsch', version: '0.1.55'
-    compile group: 'com.github.jengelman.gradle.plugins', name: 'shadow', version: '4.0.3'
-    annotationProcessor group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.11.1'
-
-    testCompile group: 'junit', name: 'junit', version: '4.12'
+    implementation gradleApi()
+    implementation localGroovy()
+    implementation      group: 'com.jcraft',                          name: 'jsch',       version: '0.1.55'
+    implementation      group: 'com.github.jengelman.gradle.plugins', name: 'shadow',     version: '4.0.3'
+    annotationProcessor group: 'org.apache.logging.log4j',            name: 'log4j-core', version: '2.11.1'
+    testImplementation  group: 'junit',                               name: 'junit',      version: '4.12'
 }

--- a/src/main/groovy/com/github/elj/gradle/Extension.groovy
+++ b/src/main/groovy/com/github/elj/gradle/Extension.groovy
@@ -108,7 +108,7 @@ class Extension {
         def jarList = []
 
         if (pref.slimJar) {
-            proj.configurations.runtime.each { path ->
+            proj.configurations.runtimeClasspath.each { path ->
                 jarList += "file://${paths.libraryDir}/${path.getName()}"
             }
         }

--- a/src/main/groovy/com/github/elj/gradle/GradlePlugin.groovy
+++ b/src/main/groovy/com/github/elj/gradle/GradlePlugin.groovy
@@ -93,7 +93,7 @@ class GradlePlugin implements Plugin<Project> {
                             }
 
                             try {
-                                proj.configurations.runtime.each {
+                                proj.configurations.runtimeClasspath.each {
                                     Path src = it.toPath()
                                     String dst = ext.paths.libraryDir + "/" + src.fileName.toString()
                                     int mode = 0644


### PR DESCRIPTION
Hi,

this PR replaces deprecated `runtime`, `compile` and `testCompile` dependency types with `runtimeClasspath`, `implementation` and `testImplementation`. This is done in both the dependency searching code and the plugin project file.

Fixes #5 and #4.

I intend to merge this to the 1.6.x branch (with tag being there) and then merge it to the master branch.

Regards