### PR TITLE
Fix JitPack build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,11 @@
 plugins {
     id 'java'
     id 'java-gradle-plugin'
-    id 'groovy'
+    id 'maven-publish'
 }
 
 group 'com.github.ev3dev-lang-java'
-version '1.6.6'
+version '1.6.7-SNAPSHOT'
 
 sourceCompatibility = 1.8
 
@@ -30,4 +30,15 @@ dependencies {
     implementation      group: 'com.jcraft',                          name: 'jsch',       version: '0.1.55'
     implementation      group: 'com.github.jengelman.gradle.plugins', name: 'shadow',     version: '4.0.3'
     testImplementation  group: 'junit',                               name: 'junit',      version: '4.12'
+}
+
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            groupId = 'com.github.ev3dev-lang-java'
+            artifactId = 'gradle-plugin'
+            version = "${version}"
+        }
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'com.github.ev3dev-lang-java'
-version '1.6.7-SNAPSHOT'
+version '1.6.7'
 
 sourceCompatibility = 1.8
 


### PR DESCRIPTION
Hi @jabrena,

sadly the build of the last change failed: https://jitpack.io/com/github/ev3dev-lang-java/gradle-plugin/1.6.6/build.log . It seems that it was caused by missing Maven Publish plugin. So I added it and it builds ok now: https://jitpack.io/com/github/ev3dev-lang-java/gradle-plugin/1.6.7-SNAPSHOT/build.log

Regards,

Jakub