### PR TITLE
Version 1.6.8: Upload splash via stream + fix plugin build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'java'
     id 'java-gradle-plugin'
+    id 'groovy'
     id 'maven-publish'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'com.github.ev3dev-lang-java'
-version '1.6.7'
+version '1.6.8'
 
 sourceCompatibility = 1.8
 

--- a/src/main/groovy/com/github/elj/gradle/GradlePlugin.groovy
+++ b/src/main/groovy/com/github/elj/gradle/GradlePlugin.groovy
@@ -7,7 +7,6 @@ import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPlugin
 
 import java.nio.charset.StandardCharsets
-import java.nio.file.StandardCopyOption
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -206,16 +205,10 @@ class GradlePlugin implements Plugin<Project> {
                                 // provide a default splash
                                 Path splash = ext.localSplashPath()
                                 if (!Files.exists(splash)) {
-                                    System.out.println "[Using default splash, copying to a temporary file.]"
-                                    splash = Files.createTempFile("splash-", ".txt");
-
                                     InputStream str = null
-
                                     try {
                                         str = GradlePlugin.class.getResourceAsStream("/splash.txt")
-                                        Files.copy(str, splash, StandardCopyOption.REPLACE_EXISTING)
-                                        put splash, ext.brickSplashPath(), 0644
-                                        Files.delete(splash)
+                                        putStream str, "[default splash]", ext.brickSplashPath(), 0644
                                     } finally {
                                         str?.close()
                                     }

--- a/src/main/groovy/com/github/elj/gradle/SFTP.groovy
+++ b/src/main/groovy/com/github/elj/gradle/SFTP.groovy
@@ -29,6 +29,15 @@ class SFTP implements AutoCloseable {
         }
     }
 
+    void putStream(InputStream stream, String name, String destination, int mode) throws Exception {
+        System.out.println("Uploading file from stream: " + name);
+
+        sftp.with {
+            put stream, destination, OVERWRITE
+            chmod mode, destination
+        }
+    }
+
     void mkdir(String destination) throws Exception {
         try {
             sftp.with {


### PR DESCRIPTION
This PR hopefully fixes #10 and then fixes the build of the plugin. When I was fixing the JitPack maven-publish issue, I accidentally deleted the groovy plugin, so the plugin was effectively empty. It is working properly now.