### PR TITLE
Unify deployment code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group 'com.github.ev3dev-lang-java'
-version '1.6.11'
+version '2.0.0-SNAPSHOT'
 
 sourceCompatibility = 11
 targetCompatibility = 11

--- a/src/main/groovy/com/github/elj/gradle/DeploymentTask.groovy
+++ b/src/main/groovy/com/github/elj/gradle/DeploymentTask.groovy
@@ -1,0 +1,147 @@
+package com.github.elj.gradle
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+class DeploymentTask extends DefaultTask {
+
+    @Input
+    boolean isLibrary = false
+
+    @TaskAction
+    void deploy() throws Exception {
+        SSH ssh = null
+        SFTP sftp = null
+        try {
+            System.out.println("/ Connecting...")
+            try {
+                ssh = new SSH(project.brick)
+                sftp = ssh.openFileMode()
+            } catch (GradleException e) {
+                throw e
+            } catch (Exception e) {
+                throw new GradleException("SSH connection failed", e)
+            }
+
+            deployMkdir(sftp)
+            deployDependencies(sftp)
+            deployJar(sftp)
+            deployLauncher(sftp)
+            deployExtras(sftp)
+
+        } catch (GradleException e) {
+            throw e
+        } catch (Exception e) {
+            throw new GradleException("Program upload failed.", e)
+        } finally {
+            sftp?.close()
+            ssh?.close()
+        }
+    }
+
+    private void deployMkdir(SFTP sftp) throws Exception {
+        System.out.println("/ Ensuring on-brick directory structure...")
+        try {
+            Extension ext = project.brick
+            sftp.mkdir ext.paths.wrapperDir
+            sftp.mkdir ext.paths.javaDir
+            sftp.mkdir ext.paths.splashDir
+            sftp.mkdir ext.paths.programDir
+            sftp.mkdir ext.paths.libraryDir
+        } catch (Exception e) {
+            throw new GradleException("Creation of on-brick directories failed.", e)
+        }
+    }
+
+    private void deployDependencies(SFTP sftp) throws Exception {
+        System.out.println("/ Checking on-brick Java libraries...")
+        try {
+            Extension ext = project.brick
+            project.configurations.runtimeClasspath.each {
+                Path src = it.toPath()
+                String dst = ext.paths.libraryDir + "/" + src.fileName.toString()
+                int mode = 0644
+
+                sftp.putIfNonexistent src, dst, mode
+            }
+        } catch (Exception e) {
+            throw new GradleException("Upload of Gradle libraries failed.", e)
+        }
+    }
+
+    private void deployJar(SFTP sftp) throws Exception {
+        Extension ext = project.brick
+
+        String remotePath
+        if (isLibrary) {
+            System.out.println("/ Uploading library JAR...")
+            remotePath = ext.brickLibraryPath()
+        } else {
+            System.out.println("/ Uploading program JAR...")
+            remotePath = ext.brickProgramPath()
+        }
+        sftp.with {
+            try {
+                put ext.localProgramPath(), remotePath, 0644
+            } catch (Exception e) {
+                throw new GradleException("Upload of program files failed.", e)
+            }
+        }
+    }
+
+    private void deployLauncher(SFTP sftp) throws Exception {
+        if (!isLibrary) {
+            System.out.println("/ Uploading program launcher...")
+            try {
+                Extension ext = project.brick
+                sftp.put ext.localWrapperPath(), ext.brickWrapperPath(), 0755
+
+                // provide a default splash
+                Path splash = ext.localSplashPath()
+                if (!Files.exists(splash)) {
+                    InputStream str = null
+                    try {
+                        str = GradlePlugin.class.getResourceAsStream("/splash.txt")
+                        sftp.putStream str, "[default splash]", ext.brickSplashPath(), 0644
+                    } finally {
+                        str?.close()
+                    }
+                } else {
+                    sftp.put splash, ext.brickSplashPath(), 0644
+                }
+
+            } catch (Exception e) {
+                throw new GradleException("Upload of program files failed.", e)
+            }
+        }
+    }
+
+    private void deployExtras(SFTP sftp) throws Exception {
+        try {
+            Extension ext = project.brick
+            List uploads = ext.build.uploads.call(project)
+
+            if (!uploads.empty) {
+                System.out.println("/ Uploading additional files...")
+                uploads.each { it ->
+                    Path src = it[0] as Path
+                    String dst = it[1] as String
+                    int mode = it[2] as Integer
+
+                    if (!src.toFile().exists()) {
+                        throw new GradleException("Source file '${src.toString()}' does not exist.")
+                    } else {
+                        sftp.put src, dst, mode
+                    }
+                }
+            }
+        } catch (Exception e) {
+            throw new GradleException("Upload of additional files failed.", e)
+        }
+    }
+}

--- a/src/main/groovy/com/github/elj/gradle/Extension.groovy
+++ b/src/main/groovy/com/github/elj/gradle/Extension.groovy
@@ -143,6 +143,15 @@ class Extension {
         }
     }
 
+    SetupTask setupTask(String grpName, String name, command, String desc) {
+        return proj.tasks.create(name, SetupTask).with {
+            setCommand command
+            setGroup grpName
+            setDescription desc
+            return it
+        }
+    }
+
     RemoteCommandTask sudoTask(String grpName, String name, commands, String desc) {
         def list = []
 

--- a/src/main/groovy/com/github/elj/gradle/GradlePlugin.groovy
+++ b/src/main/groovy/com/github/elj/gradle/GradlePlugin.groovy
@@ -8,7 +8,6 @@ import org.gradle.api.plugins.JavaPlugin
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
-import java.nio.file.Path
 import java.nio.file.Paths
 
 class GradlePlugin implements Plugin<Project> {
@@ -20,12 +19,12 @@ class GradlePlugin implements Plugin<Project> {
 
         Extension ext = project.extensions.create("brick", Extension, project)
 
-        registerInstallerTasks(project, ext)
+        registerInstallerTasks(ext)
         registerSystemTasks(ext)
         registerDeploymentTasks(project, ext)
     }
 
-    private static void registerInstallerTasks(Project proj, Extension ext) {
+    private static void registerInstallerTasks(Extension ext) {
         final String group = "ELJ-Setup"
 
         ext.with {
@@ -34,55 +33,6 @@ class GradlePlugin implements Plugin<Project> {
 
             setupTask(group, "setupEverythingExpert", "setupBig",
                     "All-In-One installer; installs full JDK on the brick (overkill for normal use)")
-        }
-
-        proj.with {
-            task("uploadGradleLibraries").with {
-                setGroup group
-                setDescription "Install libraries specified in the project dependencies to the brick."
-
-                doLast({ task ->
-                    SSH ssh = null
-                    SFTP sftp = null
-                    try {
-                        try {
-                            ssh = new SSH(ext);
-                            sftp = ssh.openFileMode();
-                        } catch (GradleException e) {
-                            throw e
-                        } catch (Exception e) {
-                            throw new GradleException("SSH connection failed", e)
-                        }
-
-                        sftp.with {
-                            try {
-                                mkdir ext.paths.libraryDir
-                            } catch (Exception e) {
-                                throw new GradleException("Creation of on-brick library directory failed.", e)
-                            }
-
-                            try {
-                                proj.configurations.runtimeClasspath.each {
-                                    Path src = it.toPath()
-                                    String dst = ext.paths.libraryDir + "/" + src.fileName.toString()
-                                    int mode = 0644
-
-                                    put src, dst, mode
-                                }
-                            } catch (Exception e) {
-                                throw new GradleException("Upload of Gradle libraries failed.", e)
-                            }
-                        }
-                    } catch (GradleException e) {
-                        throw e
-                    } catch (Exception e) {
-                        throw new GradleException("Library upload failed.", e)
-                    } finally {
-                        sftp?.close()
-                        ssh?.close()
-                    }
-                })
-            }
         }
     }
 
@@ -118,6 +68,9 @@ class GradlePlugin implements Plugin<Project> {
             cmdTask(group, "undeploy",
                     ["rm -f ${-> ext.brickProgramPath()} ${-> ext.brickWrapperPath()} ${-> ext.brickSplashPath()}"],
                     "Remove previously uploaded JAR.")
+            cmdTask(group, "undeployLibrary",
+                    ["rm -f ${-> ext.brickLibraryPath()}"],
+                    "Remove previously uploaded JAR (library mode).")
 
             cmdTask(group, "run",
                     ["${-> ext.getJavaCommand(false)}"],
@@ -140,122 +93,18 @@ class GradlePlugin implements Plugin<Project> {
                 })
             }
 
-            task("deploy").with {
+            tasks.create("deploy", DeploymentTask).with {
                 setGroup group
                 setDescription "Deploy a new build of the program to the brick."
+                setIsLibrary false
                 dependsOn "clean", "templateWrapper", "${-> ext.pref.slimJar ? "jar" : "shadowJar"}"
-
-                doLast({ task ->
-                    SSH ssh = null
-                    SFTP sftp = null
-                    try {
-                        try {
-                            ssh = new SSH(ext);
-                            sftp = ssh.openFileMode();
-                        } catch (GradleException e) {
-                            throw e
-                        } catch (Exception e) {
-                            throw new GradleException("SSH connection failed", e)
-                        }
-
-                        sftp.with {
-                            try {
-                                mkdir ext.paths.wrapperDir
-                                mkdir ext.paths.splashDir
-                                mkdir ext.paths.programDir
-                            } catch (Exception e) {
-                                throw new GradleException("Creation of on-brick directories failed.", e)
-                            }
-
-                            try {
-                                put ext.localProgramPath(), ext.brickProgramPath(), 0644
-                                put ext.localWrapperPath(), ext.brickWrapperPath(), 0755
-
-                                // provide a default splash
-                                Path splash = ext.localSplashPath()
-                                if (!Files.exists(splash)) {
-                                    InputStream str = null
-                                    try {
-                                        str = GradlePlugin.class.getResourceAsStream("/splash.txt")
-                                        putStream str, "[default splash]", ext.brickSplashPath(), 0644
-                                    } finally {
-                                        str?.close()
-                                    }
-                                } else {
-                                    put splash, ext.brickSplashPath(), 0644
-                                }
-
-                            } catch (Exception e) {
-                                throw new GradleException("Upload of program files failed.", e)
-                            }
-
-                            ext.build.uploads.call(proj).each {
-                                Path src = it[0] as Path
-                                if (!src.toFile().exists()) {
-                                    throw new GradleException("Source file '${src.toString()}' does not exist.")
-                                }
-                                put it[0] as Path, it[1] as String, it[2] as int
-                            }
-                        }
-                    } catch (GradleException e) {
-                        throw e
-                    } catch (Exception e) {
-                        throw new GradleException("Program upload failed.", e)
-                    } finally {
-                        sftp?.close()
-                        ssh?.close()
-                    }
-                })
             }
 
-            task("deployLibrary").with {
+            tasks.create("deployLibrary", DeploymentTask).with {
                 setGroup group
                 setDescription "Deploy a new build of a library to the brick."
+                setIsLibrary true
                 dependsOn "clean", "${-> ext.pref.slimJar ? "jar" : "shadowJar"}"
-
-                doLast({ task ->
-                    SSH ssh = null
-                    SFTP sftp = null
-                    try {
-                        try {
-                            ssh = new SSH(ext);
-                            sftp = ssh.openFileMode();
-                        } catch (GradleException e) {
-                            throw e
-                        } catch (Exception e) {
-                            throw new GradleException("SSH connection failed", e)
-                        }
-
-                        sftp.with {
-                            try {
-                                mkdir ext.paths.libraryDir
-                            } catch (Exception e) {
-                                throw new GradleException("Creation of on-brick directories failed.", e)
-                            }
-
-                            try {
-                                put ext.localProgramPath(), ext.brickLibraryPath(), 0644
-                            } catch (Exception e) {
-                                throw new GradleException("Upload of program files failed.", e)
-                            }
-
-                            ext.build.uploads.call(proj).each {
-                                Path src = it[0] as Path
-                                if (!src.toFile().exists()) {
-                                    throw new GradleException("Source file '${src.toString()}' does not exist.")
-                                }
-                                put it[0] as Path, it[1] as String, it[2] as int
-                            }
-                        }
-                    } catch (GradleException e) {
-                        throw e
-                    } catch (Exception e) {
-                        throw new GradleException("Program upload failed.", e)
-                    } finally {
-                        sftp?.close()
-                        ssh?.close()
-                    }
-                })
             }
 
             task("deployRun").with {

--- a/src/main/groovy/com/github/elj/gradle/GradlePlugin.groovy
+++ b/src/main/groovy/com/github/elj/gradle/GradlePlugin.groovy
@@ -26,44 +26,14 @@ class GradlePlugin implements Plugin<Project> {
     }
 
     private static void registerInstallerTasks(Project proj, Extension ext) {
-        final String group = "ELJ-Installer"
+        final String group = "ELJ-Setup"
 
         ext.with {
-            cmdTask(group, "getInstaller",
-                    [
-                            "mkdir -p /home/robot/java",
-                            "/bin/sh -c \"if grep -i jessie /etc/os-release; then wget https://raw.githubusercontent.com/ev3dev-lang-java/installer/master/installer-jessie.sh -O /home/robot/java/installer.sh; else wget https://raw.githubusercontent.com/ev3dev-lang-java/installer/master/installer.sh -O /home/robot/java/installer.sh; fi\"",
-                            "chmod +x /home/robot/java/installer.sh"
-                    ],
-                    "Download component installer on the brick.")
+            setupTask(group, "setupEverything", "setupSmall",
+                    "All-In-One installer; installs just JRI/JRE (enough for most uses)")
 
-            sudoTask(group, "updateAPT",
-                    ["/home/robot/java/installer.sh update"],
-                    "Update APT repositories.")
-
-            cmdTask(group, "helpInstall",
-                    ["/home/robot/java/installer.sh help"],
-                    "Print the installer help.")
-
-            sudoTask(group, "installJava",
-                    ["/home/robot/java/installer.sh java"],
-                    "Install Java on the brick.")
-
-            sudoTask(group, "installOpenCV",
-                    ["/home/robot/java/installer.sh opencv"],
-                    "Install OpenCV libraries on the brick.")
-
-            sudoTask(group, "installRXTX",
-                    ["/home/robot/java/installer.sh rxtx"],
-                    "Install RXTX library on the brick.")
-
-            sudoTask(group, "installJavaLibraries",
-                    ["/home/robot/java/installer.sh javaLibs"],
-                    "Install Java libraries on the brick.")
-
-            cmdTask(group, "javaVersion",
-                    ["java -version"],
-                    "Print Java version which is present on the brick.")
+            setupTask(group, "setupEverythingExpert", "setupBig",
+                    "All-In-One installer; installs full JDK on the brick (overkill for normal use)")
         }
 
         proj.with {
@@ -115,7 +85,6 @@ class GradlePlugin implements Plugin<Project> {
             }
         }
     }
-
 
     private static void registerSystemTasks(Extension ext) {
         String group = "ELJ-System"

--- a/src/main/groovy/com/github/elj/gradle/PathPreferences.groovy
+++ b/src/main/groovy/com/github/elj/gradle/PathPreferences.groovy
@@ -2,6 +2,7 @@ package com.github.elj.gradle
 
 class PathPreferences {
     String wrapperDir = "/home/robot"
+    String javaDir = "/home/robot/java"
     String libraryDir = "/home/robot/java/libraries"
     String programDir = "/home/robot/java/programs"
     String splashDir = "/home/robot/java/splashes"

--- a/src/main/groovy/com/github/elj/gradle/SFTP.groovy
+++ b/src/main/groovy/com/github/elj/gradle/SFTP.groovy
@@ -29,6 +29,18 @@ class SFTP implements AutoCloseable {
         }
     }
 
+    void putIfNonexistent(Path source, String destination, int mode) throws Exception {
+        try {
+            sftp.stat(destination)
+        } catch (SftpException ex) {
+            if (ex.id == ChannelSftp.SSH_FX_NO_SUCH_FILE) {
+                put(source, destination, mode)
+            } else {
+                throw ex
+            }
+        }
+    }
+
     void putStream(InputStream stream, String name, String destination, int mode) throws Exception {
         System.out.println("Uploading file from stream: " + name);
 

--- a/src/main/groovy/com/github/elj/gradle/SetupTask.groovy
+++ b/src/main/groovy/com/github/elj/gradle/SetupTask.groovy
@@ -1,0 +1,41 @@
+package com.github.elj.gradle
+
+import com.jcraft.jsch.JSchException
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+
+class SetupTask extends DefaultTask {
+    @Input
+    def command = ""
+
+    @TaskAction
+    void runSetup() throws Exception {
+        Extension ext = this.project.brick
+
+        SSH ssh = null
+        SFTP sftp = null
+        try {
+            ssh = new SSH(ext)
+            sftp = ssh.openFileMode()
+
+            InputStream setupStream = null
+            try {
+                setupStream = SetupTask.class.getResourceAsStream("/setup.sh")
+                sftp.putStream setupStream, "setup helper", "/tmp/setup.sh", 0777
+            } finally {
+                setupStream?.close()
+            }
+
+            ssh.runStdio "echo -e \"${-> ext.pref.sshPassword}\" | sudo -S /tmp/setup.sh ${command}"
+        } catch(JSchException ex) {
+            if (ex.getMessage() == "inputstream is closed") {
+                throw new GradleException("Cannot connect to the brick!")
+            }
+        } finally {
+            sftp?.close()
+            ssh?.close()
+        }
+    }
+}

--- a/src/main/resources/setup.sh
+++ b/src/main/resources/setup.sh
@@ -1,0 +1,175 @@
+#!/bin/bash
+# ev3dev-lang-java setup script
+
+####################
+### PRINT BANNER ###
+
+echo
+echo "###################################"
+echo "# EV3Dev-lang-java microInstaller #"
+echo "###################################"
+echo
+
+
+##################
+### PARSE ARGS ###
+
+if [ "$1" == "setupSmall" ]; then
+    echo "Running setup for JRI/JRE..."
+    MODE="small"
+elif [ "$1" == "setupBig" ]; then
+    echo "Running setup for JDK..."
+    MODE="full"
+else
+    echo "Unknown argument!" >&2
+    exit 1
+fi
+
+##########################
+### PLATFORM DETECTION ###
+
+# detect platform
+PLATFORM="unknown"
+if [ -d "/sys/class/power_supply/lego-ev3-battery" ] \
+|| [ -d "/sys/class/power_supply/legoev3-battery" ]; then PLATFORM="ev3";
+elif [ -d "/sys/class/power_supply/brickpi-battery"   ]; then PLATFORM="brickpi";
+elif [ -d "/sys/class/power_supply/brickpi3-battery"  ]; then PLATFORM="brickpi3";
+elif [ -d "/sys/class/power_supply/pistorms-battery"  ]; then PLATFORM="pistorms";
+fi
+if [ -n "$INSTALLER_OVERRIDE_PLATFORM" ]; then
+    PLATFORM="$INSTALLER_OVERRIDE_PLATFORM"
+fi
+
+# detect OS
+DEBIAN="unknown"
+if   grep stretch /etc/os-release >/dev/null; then DEBIAN="stretch";
+elif grep buster  /etc/os-release >/dev/null; then DEBIAN="buster";
+fi
+if [ -n "$INSTALLER_OVERRIDE_DEBIAN" ]; then
+    DEBIAN="$INSTALLER_OVERRIDE_DEBIAN"
+fi
+
+# print
+echo "Platform detected: $PLATFORM on ev3dev-$DEBIAN"
+echo
+
+if [ "$PLATFORM" = "unknown" ]; then
+    echo "Sorry, this platform is not recognized by the installer."
+    echo "This installer was designed for EV3Dev hardware."
+    echo
+    echo "Open a issue if the problem continues:"
+    echo "https://github.com/ev3dev-lang-java/ev3dev-lang-java/issues"
+    echo
+    exit 1
+fi
+
+if [ "$DEBIAN" = "unknown" ]; then
+    echo "Sorry, this OS is not recognized by the installer."
+    echo
+    echo "Open a issue if the problem continues:"
+    echo "https://github.com/ev3dev-lang-java/ev3dev-lang-java/issues"
+    echo
+    exit 1
+fi
+
+
+################
+### LET'S GO ###
+
+if [ "$PLATFORM" = "ev3" ]; then
+    if [ "$MODE" == "small" ]; then
+        # too slow
+        #echo "Running APT update"
+        #apt-get update || exit $?
+        #echo
+
+        echo "Installing JRI from ev3dev repository"
+        apt-get install --yes --no-install-recommends jri-11-ev3 || exit $?
+        echo
+
+    elif [ "$MODE" == "full" ]; then
+        # too slow
+        #echo "Running APT update"
+        #apt-get update || exit $?
+        #echo
+
+        echo "Installing full JDK manually from jenkins"
+
+        echo "Cleaning up..."
+        for i in /opt/jdk-11-ev3/bin/*; do
+            update-alternatives --remove "$i" "/opt/jdk-11-ev3/bin/$i" || true
+        done
+        rm -rf "/opt/jdk-11-ev3" /tmp/java-extract || true
+        mkdir -p /tmp/java-extract
+        echo
+
+        echo "Downloading Java..."
+        wget -nv "https://ci.adoptopenjdk.net/view/ev3dev/job/eljbuild/job/$DEBIAN-11/lastSuccessfulBuild/artifact/build/jri-ev3.tar.gz" -O /tmp/java-extract/pkg.tar.gz  || return $?
+        echo
+
+        echo "Unpacking Java..."
+        tar -C /tmp/java-extract -xf /tmp/java-extract/pkg.tar.gz
+        mv "/tmp/java-extract/jdk" "/opt/jdk-11-ev3"
+        echo
+
+        echo "Setting up symlinks..."
+        for i in /opt/jdk-11-ev3/bin/*; do
+            update-alternatives --install "/usr/bin/$i" "$i" "/opt/jdk-11-ev3/bin/$i" 1199
+        done
+        echo
+    fi
+elif [ "$PLATFORM" = "brickpi"  ] ||
+     [ "$PLATFORM" = "brickpi3" ] ||
+     [ "$PLATFORM" = "pistorms" ]; then
+
+    if [ "$DEBIAN" = "stretch" ]; then
+        echo "Adding backports repository for JRE11"
+        rm -f /etc/apt/preferences.d/jdk
+        echo "deb http://ftp.debian.org/debian stretch-backports main" | tee "/etc/apt/sources.list.d/jdk.list"
+    fi
+
+    echo "Running APT update"
+    apt-get update || exit $?
+    echo
+
+    echo "Installing JRE from Debian repo"
+    if [ "$DEBIAN" = "stretch" ]; then
+        TARGET_ARG="-t stretch-backports"
+    elif [ "$DEBIAN" = "buster" ]; then
+        TARGET_ARG=""
+    fi
+    if [ "$1" == "small" ]; then
+        apt-get install --yes --no-install-recommends $TARGET_ARG openjdk-11-jre-headless || exit $?
+    elif [ "$1" == "full" ]; then
+        apt-get install --yes --no-install-recommends $TARGET_ARG openjdk-11-jdk-headless || exit $?
+    fi
+fi
+
+echo "Installing OpenCV & RXTX libraries"
+if [ "$DEBIAN" = "stretch" ]; then
+  LIB_PKGS="libopencv2.4-java libopenmpt0 librxtx-java"
+elif [ "$DEBIAN" = "buster" ]; then
+  LIB_PKGS="libopencv3.2-java libopenmpt0=0.4.3-1 librxtx-java"
+fi
+apt-get install --yes --no-install-recommends $LIB_PKGS || exit $?
+echo
+
+########################
+### CDS OPTIMIZATION ###
+
+hash -r # remove cached java path
+
+echo "Optimizing (creating CDS cache) ..."
+java -Xshare:dump || exit $?
+echo
+
+echo "-> Java version:"
+java -version || exit $?
+echo
+
+
+#########################
+### PERMISSION FIXUP ###
+
+echo "Fixing permissions on /home/robot..."
+chown robot:robot -R /home/robot


### PR DESCRIPTION
Fixes https://github.com/ev3dev-lang-java/ev3dev-lang-java/issues/685
Merge after https://github.com/ev3dev-lang-java/gradle-plugin/pull/19

This reworks the upload/deployment code. Instead of having separate `uploadGradleLibraries`, `deploy` and `deployLibrary` code paths, everything is now unified under one common implementation.

These changes also have bigger implications. It is now possible to pick an EV3 *without* running any installer/setup target and just deploy and run the code:
```
$ ./gradlew deploy

> Task :deploy
/ Connecting...
/ Ensuring on-brick directory structure...
/ Checking on-brick Java libraries...
Uploading file: slf4j-simple-1.7.25.jar
Uploading file: ev3dev-lang-java-2.5.3.jar
Uploading file: slf4j-api-1.7.25.jar
Uploading file: lejos-commons-0.7.3.jar
Uploading file: jna-4.5.2.jar
/ Uploading program JAR...
Uploading file: template_project_gradle-2.6.0.jar
/ Uploading program launcher...
Uploading file: launcher.sh
Uploading file from stream: [default splash]

BUILD SUCCESSFUL in 8s
6 actionable tasks: 6 executed
```

Users will not have to care about uploading their libraries separately; if they add them to the `implementation()` target, they will be automatically uploaded. The only exception is RXTX/OpenCV:
* the libraries have to be installed via APT, like for instance via the `setupEverything` task.
* the system library paths then have to be added to the runtime classpath by setting `libOpenCV` or `libRXTX` in the configuration file.

On non-EV3 platforms, it is always necessary to first run `setupEverything` (to install Java); then it should work like on EV3.