### PR TITLE
build: revert back to Java 8 for building the plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - openjdk11
+  - openjdk8
 before_install:
   - chmod +x gradlew
 notifications:

--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,8 @@ plugins {
 group 'com.github.ev3dev-lang-java'
 version '2.0.0'
 
-sourceCompatibility = 11
-targetCompatibility = 11
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 repositories {
     jcenter()

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group 'com.github.ev3dev-lang-java'
-version '2.0.0'
+version '2.0.1'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8


### PR DESCRIPTION
Many IDEs still use Java 8 as their default Gradle JVM and they need to be manually reconfigured to use a newer one. This creates a worse experience for new users of template-project-gradle.

Relates to ev3dev-lang-java/ev3dev-lang-java#714